### PR TITLE
Feature/form

### DIFF
--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -69,7 +69,7 @@ http.interceptors.request.use((config) => {
   config.params.auth_key = state.apiKey;
 
   if("target_lang" in config.params) {
-    if(formalityAllowed.indexOf(config.params.target_lang) > -1) {
+    if(formalityAllowed.indexOf(state.formality) > -1) {
       config.params.formality = state.formality;
     }
   }

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -55,6 +55,8 @@ type ErrorHandler = (e: DeepLException) => void;
 const http = axios.create();
 const errorHandlers: ErrorHandler[] = [];
 
+const formalityAllowed: string[] = ["DE", "FR", "IT", "ES", "NL", "PL", "PT-PT", "PT-BR", "RU"];
+
 http.interceptors.request.use((config) => {
   config.baseURL = state.usePro
     ? 'https://api.deepl.com'
@@ -65,7 +67,13 @@ http.interceptors.request.use((config) => {
   }
 
   config.params.auth_key = state.apiKey;
-  config.params.formality = state.formality;
+
+  if("target_lang" in config.params) {
+    if(formalityAllowed.indexOf(config.params.target_lang) > -1) {
+      config.params.formality = state.formality;
+    }
+  }
+
   config.params.split_sentences = state.splitSentences;
   config.params.preserve_formatting = state.preserveFormatting ? "1" : "0";
   


### PR DESCRIPTION
I can correctly translate to languages that support formality, which leads me to believe that this PR could fix #13.
Again untested, feel free to take this idea and finalize it.

<html><body>
<!--StartFragment-->

formality | Optional | Sets  whether the translated text should lean towards formal or informal  language. This feature currently only works for target languages "DE"  (German), "FR" (French), "IT" (Italian), "ES" (Spanish), "NL" (Dutch),  "PL" (Polish), "PT-PT", "PT-BR" (Portuguese) and "RU" (Russian).
-- | -- | --


<!--EndFragment-->
</body>
</html>